### PR TITLE
Making Submit a public function so I can send metrics pre-formatted

### DIFF
--- a/statsd/main.go
+++ b/statsd/main.go
@@ -13,6 +13,7 @@ type Statter interface {
 	Gauge(stat string, value int64, rate float32) error
 	GaugeDelta(stat string, value int64, rate float32) error
 	Timing(stat string, delta int64, rate float32) error
+	Submit(stat string, value string, rate float32) error
 	SetPrefix(prefix string)
 	Close() error
 }
@@ -39,7 +40,7 @@ func (s *Client) Close() error {
 // rate is the sample rate (0.0 to 1.0)
 func (s *Client) Inc(stat string, value int64, rate float32) error {
 	dap := fmt.Sprintf("%d|c", value)
-	return s.submit(stat, dap, rate)
+	return s.Submit(stat, dap, rate)
 }
 
 // Decrements a statsd count type.
@@ -56,7 +57,7 @@ func (s *Client) Dec(stat string, value int64, rate float32) error {
 // rate is the sample rate (0.0 to 1.0).
 func (s *Client) Gauge(stat string, value int64, rate float32) error {
 	dap := fmt.Sprintf("%d|g", value)
-	return s.submit(stat, dap, rate)
+	return s.Submit(stat, dap, rate)
 }
 
 // Submits a delta to a statsd gauge.
@@ -65,7 +66,7 @@ func (s *Client) Gauge(stat string, value int64, rate float32) error {
 // rate is the sample rate (0.0 to 1.0).
 func (s *Client) GaugeDelta(stat string, value int64, rate float32) error {
 	dap := fmt.Sprintf("%+d|g", value)
-	return s.submit(stat, dap, rate)
+	return s.Submit(stat, dap, rate)
 }
 
 // Submits a statsd timing type.
@@ -74,7 +75,7 @@ func (s *Client) GaugeDelta(stat string, value int64, rate float32) error {
 // rate is the sample rate (0.0 to 1.0).
 func (s *Client) Timing(stat string, delta int64, rate float32) error {
 	dap := fmt.Sprintf("%d|ms", delta)
-	return s.submit(stat, dap, rate)
+	return s.Submit(stat, dap, rate)
 }
 
 // Sets/Updates the statsd client prefix
@@ -82,9 +83,9 @@ func (s *Client) SetPrefix(prefix string) {
 	s.prefix = prefix
 }
 
-// submit formats the statsd event data, handles sampling, and prepares it,
+// Submit formats the statsd event data, handles sampling, and prepares it,
 // and sends it to the server.
-func (s *Client) submit(stat string, value string, rate float32) error {
+func (s *Client) Submit(stat string, value string, rate float32) error {
 	if rate < 1 {
 		if rand.Float32() < rate {
 			value = fmt.Sprintf("%s|@%f", value, rate)


### PR DESCRIPTION
I was porting a project that used Lynx to directly post metrics to a statsd client without adding additional characters to the value, I didn't see a way to do that with this so I added it.
