### PR TITLE
replace noop client with support for nil receiver

### DIFF
--- a/statsd/main.go
+++ b/statsd/main.go
@@ -29,6 +29,9 @@ type Client struct {
 
 // Close closes the connection and cleans up.
 func (s *Client) Close() error {
+	if s == nil {
+		return nil
+	}
 	err := s.c.Close()
 	return err
 }
@@ -83,6 +86,9 @@ func (s *Client) Timing(stat string, delta int64, rate float32) error {
 // value is a preformatted "raw" value string.
 // rate is the sample rate (0.0 to 1.0).
 func (s *Client) Raw(stat string, value string, rate float32) error {
+	if s == nil {
+		return nil
+	}
 	if rate < 1 {
 		if rand.Float32() < rate {
 			value = fmt.Sprintf("%s|@%f", value, rate)
@@ -106,6 +112,9 @@ func (s *Client) Raw(stat string, value string, rate float32) error {
 
 // Sets/Updates the statsd client prefix
 func (s *Client) SetPrefix(prefix string) {
+	if s == nil {
+		return
+	}
 	s.prefix = prefix
 }
 

--- a/statsd/test-client/main.go
+++ b/statsd/test-client/main.go
@@ -20,7 +20,7 @@ func main() {
 		Name      string        `short:"n" long:"name" default:"counter" description:"stat name"`
 		Rate      float32       `short:"r" long:"rate" default:"1.0" description:"sample rate"`
 		Volume    int           `short:"c" long:"count" default:"1000" description:"Number of stats to send. Volume."`
-		Noop      bool          `long:"noop" default:"false" description:"Use noop client"`
+		Nil       bool          `long:"nil" default:"false" description:"Use nil client"`
 		Duration  time.Duration `short:"d" long:"duration" default:"10s" description:"How long to spread the volume across. Each second of duration volume/seconds events will be sent."`
 	}
 
@@ -36,15 +36,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	var client statsd.Statter
-	if !opts.Noop {
+	var client *statsd.Client
+	if !opts.Nil {
 		client, err = statsd.New(opts.HostPort, opts.Prefix)
 		if err != nil {
 			log.Fatal(err)
 		}
 		defer client.Close()
-	} else {
-		client, err = statsd.NewNoop(opts.HostPort, opts.Prefix)
 	}
 
 	var stat func(stat string, value int64, rate float32) error


### PR DESCRIPTION
It's up to you if you want to merge this, obviously, but I like this API pattern better for things that are optional like a statsd client.

You don't have to initialize a `*Client` if you don't want to (even a `NoopClient`), and you don't have to conditionalize calls to the client.  Win win!
