### PR TITLE
a buffered client that sends multiple metrics in one UDP packet

### DIFF
--- a/statsd/buffered.go
+++ b/statsd/buffered.go
@@ -67,11 +67,13 @@ func NewBufferedSender(addr string, flushIntervalBytes, flushIntervalMillis int)
 	return sender, nil
 }
 
-// Returns a pointer to a new Client, and an error.
-// addr is a string of the format "hostname:port", and must be parsable by
-// net.ResolveUDPAddr.
-// prefix is the statsd client prefix. Can be "" if no prefix is desired.
 func NewBufferedClient(addr, prefix string, flushIntervalBytes, flushIntervalMillis int) (*Client, error) {
+	if flushIntervalBytes <= 0 {
+		flushIntervalBytes = 1432 // https://github.com/etsy/statsd/blob/master/docs/metric_types.md#multi-metric-packets
+	}
+	if flushIntervalMillis <= 0 {
+		flushIntervalMillis = 1000
+	}
 	sender, err := NewBufferedSender(addr, flushIntervalBytes, flushIntervalMillis)
 	if err != nil {
 		return nil, err

--- a/statsd/buffered.go
+++ b/statsd/buffered.go
@@ -31,7 +31,9 @@ func (s *BufferedSender) Start() {
 	for {
 		select {
 		case <-ticker.C:
-			s.flush()
+			if s.buffer.Len() > 0 {
+				s.flush()
+			}
 		case req := <-s.reqs:
 			// StatsD supports receiving multiple metrics in a single packet by separating them with a newline.
 			newLine := append(req, '\n')

--- a/statsd/buffered.go
+++ b/statsd/buffered.go
@@ -1,0 +1,86 @@
+package statsd
+
+import (
+	"time"
+)
+
+type BufferedSender struct {
+	flushIntervalBytes  int
+	flushIntervalMillis int
+	sender              *SimpleSender
+	buffer              []byte
+	reqs                chan []byte
+	shutdown            chan bool
+}
+
+func (s *BufferedSender) Send(data []byte) (int, error) {
+	s.reqs <- data
+	return len(data), nil
+}
+
+func (s *BufferedSender) Close() error {
+	s.shutdown <- true
+	err := s.sender.Close()
+	return err
+}
+
+func (s *BufferedSender) Start() {
+	ticker := time.NewTicker(time.Duration(s.flushIntervalMillis) * time.Millisecond)
+
+	for {
+		select {
+		case <-ticker.C:
+			s.flush()
+		case req := <-s.reqs:
+			// StatsD supports receiving multiple metrics in a single packet by separating them with a newline.
+			s.buffer = append(s.buffer, append(req, []byte("\n")...)...)
+			if len(s.buffer) >= s.flushIntervalBytes {
+				s.flush()
+			}
+		case <-s.shutdown:
+			break
+		}
+	}
+}
+
+func (s *BufferedSender) flush() (int, error) {
+	n, err := s.sender.Send(s.buffer)
+	s.buffer = []byte{} // clear the buffer
+	return n, err
+}
+
+func NewBufferedSender(addr string, flushIntervalBytes, flushIntervalMillis int) (*BufferedSender, error) {
+	simpleSender, err := NewSimpleSender(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	sender := &BufferedSender{
+		flushIntervalBytes:  flushIntervalBytes,
+		flushIntervalMillis: flushIntervalMillis,
+		sender:              simpleSender,
+		reqs:                make(chan []byte),
+		shutdown:            make(chan bool),
+	}
+
+	go sender.Start()
+	return sender, nil
+}
+
+// Returns a pointer to a new Client, and an error.
+// addr is a string of the format "hostname:port", and must be parsable by
+// net.ResolveUDPAddr.
+// prefix is the statsd client prefix. Can be "" if no prefix is desired.
+func NewBufferedClient(addr, prefix string, flushIntervalBytes, flushIntervalMillis int) (*Client, error) {
+	sender, err := NewBufferedSender(addr, flushIntervalBytes, flushIntervalMillis)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &Client{
+		prefix: prefix,
+		sender: sender,
+	}
+
+	return client, nil
+}

--- a/statsd/buffered_test.go
+++ b/statsd/buffered_test.go
@@ -1,0 +1,106 @@
+package statsd
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestBufferedClient(t *testing.T) {
+	l, err := newUDPListener("127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	for _, tt := range statsdPacketTests {
+		c, err := NewBufferedClient(l.LocalAddr().String(), tt.Prefix, 100, 10)
+		if err != nil {
+			c.Close()
+			t.Fatal(err)
+		}
+		method := reflect.ValueOf(c).MethodByName(tt.Method)
+		e := method.Call([]reflect.Value{
+			reflect.ValueOf(tt.Stat),
+			reflect.ValueOf(tt.Value),
+			reflect.ValueOf(tt.Rate)})[0]
+		errInter := e.Interface()
+		if errInter != nil {
+			c.Close()
+			t.Fatal(errInter.(error))
+		}
+
+		data := make([]byte, 128)
+		_, _, err = l.ReadFrom(data)
+		if err != nil {
+			c.Close()
+			t.Fatal(err)
+		}
+
+		data = bytes.TrimRight(data, "\x00\n")
+		if bytes.Equal(data, []byte(tt.Expected)) != true {
+			t.Fatalf("%s got '%s' expected '%s'", tt.Method, data, tt.Expected)
+		}
+		c.Close()
+	}
+}
+
+var statsdPacketTests2 = []struct {
+	Prefix   string
+	Method   string
+	Stat     string
+	Value    int64
+	Rate     float32
+	Expected string
+}{
+	{"test", "Gauge", "gauge", 1, 1.0, "test.gauge:1|g"},
+	{"test", "Inc", "count", 1, 0.999999, "test.count:1|c|@0.999999"},
+	{"test", "Inc", "count", 1, 1.0, "test.count:1|c"},
+	{"test", "Dec", "count", 1, 1.0, "test.count:-1|c"},
+	{"test", "Timing", "timing", 1, 1.0, "test.timing:1|ms"},
+	{"test", "Inc", "count", 1, 1.0, "test.count:1|c"},
+	{"test", "GaugeDelta", "gauge", 1, 1.0, "test.gauge:+1|g"},
+	{"test", "GaugeDelta", "gauge", -1, 1.0, "test.gauge:-1|g"},
+}
+
+func TestBufferedClient2(t *testing.T) {
+	l, err := newUDPListener("127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	c, err := NewBufferedClient(l.LocalAddr().String(), "test", 1024, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	for _, tt := range statsdPacketTests2 {
+		method := reflect.ValueOf(c).MethodByName(tt.Method)
+		e := method.Call([]reflect.Value{
+			reflect.ValueOf(tt.Stat),
+			reflect.ValueOf(tt.Value),
+			reflect.ValueOf(tt.Rate)})[0]
+		errInter := e.Interface()
+		if errInter != nil {
+			t.Fatal(errInter.(error))
+		}
+	}
+
+	var expected string
+	for _, tt := range statsdPacketTests2 {
+		expected = expected + tt.Expected + "\n"
+	}
+
+	data := make([]byte, 1024)
+	_, _, err = l.ReadFrom(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data = bytes.TrimRight(data, "\x00")
+	if bytes.Equal(data, []byte(expected)) != true {
+		t.Fatalf("got '%s' expected '%s'", data, expected)
+	}
+}

--- a/statsd/main.go
+++ b/statsd/main.go
@@ -18,13 +18,16 @@ type Statter interface {
 	Close() error
 }
 
+type Sender interface {
+	Send(data []byte) (int, error)
+	Close() error
+}
+
 type Client struct {
-	// underlying connection
-	c net.PacketConn
-	// resolved udp address
-	ra *net.UDPAddr
 	// prefix for statsd name
 	prefix string
+	// packet sender
+	sender Sender
 }
 
 // Close closes the connection and cleans up.
@@ -32,7 +35,7 @@ func (s *Client) Close() error {
 	if s == nil {
 		return nil
 	}
-	err := s.c.Close()
+	err := s.sender.Close()
 	return err
 }
 
@@ -103,7 +106,7 @@ func (s *Client) Raw(stat string, value string, rate float32) error {
 
 	data := fmt.Sprintf("%s:%s", stat, value)
 
-	_, err := s.send([]byte(data))
+	_, err := s.sender.Send([]byte(data))
 	if err != nil {
 		return err
 	}
@@ -118,11 +121,18 @@ func (s *Client) SetPrefix(prefix string) {
 	s.prefix = prefix
 }
 
-// sends the data to the server endpoint
-func (s *Client) send(data []byte) (int, error) {
+type SimpleSender struct {
+	// underlying connection
+	c net.PacketConn
+	// resolved udp address
+	ra *net.UDPAddr
+}
+
+// Send sends the data to the server endpoint
+func (s *SimpleSender) Send(data []byte) (int, error) {
 	// no need for locking here, as the underlying fdNet
 	// already serialized writes
-	n, err := s.c.(*net.UDPConn).WriteToUDP([]byte(data), s.ra)
+	n, err := s.c.(*net.UDPConn).WriteToUDP(data, s.ra)
 	if err != nil {
 		return 0, err
 	}
@@ -132,11 +142,12 @@ func (s *Client) send(data []byte) (int, error) {
 	return n, nil
 }
 
-// Returns a pointer to a new Client, and an error.
-// addr is a string of the format "hostname:port", and must be parsable by
-// net.ResolveUDPAddr.
-// prefix is the statsd client prefix. Can be "" if no prefix is desired.
-func New(addr, prefix string) (*Client, error) {
+func (s *SimpleSender) Close() error {
+	err := s.c.Close()
+	return err
+}
+
+func NewSimpleSender(addr string) (*SimpleSender, error) {
 	c, err := net.ListenPacket("udp", ":0")
 	if err != nil {
 		return nil, err
@@ -147,10 +158,28 @@ func New(addr, prefix string) (*Client, error) {
 		return nil, err
 	}
 
+	sender := &SimpleSender{
+		c:  c,
+		ra: ra,
+	}
+
+	return sender, nil
+}
+
+// Returns a pointer to a new Client, and an error.
+// addr is a string of the format "hostname:port", and must be parsable by
+// net.ResolveUDPAddr.
+// prefix is the statsd client prefix. Can be "" if no prefix is desired.
+func New(addr, prefix string) (*Client, error) {
+	sender, err := NewSimpleSender(addr)
+	if err != nil {
+		return nil, err
+	}
+
 	client := &Client{
-		c:      c,
-		ra:     ra,
-		prefix: prefix}
+		prefix: prefix,
+		sender: sender,
+	}
 
 	return client, nil
 }


### PR DESCRIPTION
Refactored the `Client` type to take a `Sender` as a parameter. The standard client uses a `SimpleSender` to generate one packet per metric. The buffered client uses a `BufferedSender` to buffer the metrics in memory and flush only on a time interval or when the buffer reaches a certain size.

This change is backward compatible, i.e., clients can upgrade without needing code change. 