### PR TITLE
Use a sync.Pool to reduce GC in BufferedSender

### DIFF
--- a/statsd/buffer_pool.go
+++ b/statsd/buffer_pool.go
@@ -20,11 +20,10 @@ func newBufferPool() *bufferPool {
 }
 
 func (bp *bufferPool) Get() *bytes.Buffer {
-	b := (bp.Pool.Get()).(*bytes.Buffer)
-	b.Truncate(0)
-	return b
+	return (bp.Pool.Get()).(*bytes.Buffer)
 }
 
 func (bp *bufferPool) Put(b *bytes.Buffer) {
+	b.Truncate(0)
 	bp.Pool.Put(b)
 }

--- a/statsd/buffer_pool.go
+++ b/statsd/buffer_pool.go
@@ -1,0 +1,30 @@
+package statsd
+
+import (
+	"bytes"
+	"sync"
+)
+
+type bufferPool struct {
+	sync.Pool
+}
+
+func newBufferPool() *bufferPool {
+	bp := &bufferPool{}
+
+	bp.New = func() interface{} {
+		return &bytes.Buffer{}
+	}
+
+	return bp
+}
+
+func (bp *bufferPool) Get() *bytes.Buffer {
+	b := (bp.Pool.Get()).(*bytes.Buffer)
+	b.Truncate(0)
+	return b
+}
+
+func (bp *bufferPool) Put(b *bytes.Buffer) {
+	bp.Pool.Put(b)
+}


### PR DESCRIPTION
This also meant switching from []byte to *Buffer. []byte can't be used
directly, instead you would have to use a *[]byte. This seemed uglier
than just switching to *Buffer which supports truncating.

These changes have shown to greatly reduce the number of objects my
application is generating.