### PR TITLE
Handle Client with empty base prefix

### DIFF
--- a/statsd/client.go
+++ b/statsd/client.go
@@ -270,13 +270,13 @@ func (s *Client) SetPrefix(prefix string) {
 }
 
 // NewSubStatter returns a SubStatter with appended prefix
-func (s *Client) NewSubStatter(prefix string) SubStatter {
+func (s *Client) NewSubStatter(newScope string) SubStatter {
 	var c *Client
 	if s != nil {
-		subfix := dotprefix(prefix)
+		newScope := dotsuffix(s.prefix, newScope)
 
 		c = &Client{
-			prefix:  s.prefix + subfix,
+			prefix:  s.prefix + newScope,
 			sender:  s.sender,
 			sampler: s.sampler,
 		}
@@ -305,12 +305,19 @@ func NewClient(addr, prefix string) (Statter, error) {
 }
 
 // helper method to ensure a dot is added only when necessary
-func dotprefix(prefix string) string {
-	if prefix != "" && !strings.HasPrefix(prefix, ".") {
-		return "." + prefix
+func dotsuffix(curPrefix, suffix string) string {
+	var (
+		emptyBase      = curPrefix == ""
+		baseHasDot     = strings.HasSuffix(curPrefix, ".")
+		emptySuffix    = suffix == ""
+		suffixLeadsDot = strings.HasPrefix(suffix, ".")
+	)
+
+	if !emptyBase && !baseHasDot && !suffixLeadsDot && !emptySuffix {
+		return "." + suffix
 	}
 
-	return prefix
+	return suffix
 }
 
 // Dial is a compatibility alias for NewClient

--- a/statsd/client.go
+++ b/statsd/client.go
@@ -269,14 +269,13 @@ func (s *Client) SetPrefix(prefix string) {
 	s.prefix = prefix
 }
 
-// NewSubStatter returns a SubStatter with appended prefix
+// NewSubStatter returns a SubStatter with an updated prefix that equals the
+// old prefix with 'newScope' appended.
 func (s *Client) NewSubStatter(newScope string) SubStatter {
 	var c *Client
 	if s != nil {
-		newScope := dotsuffix(s.prefix, newScope)
-
 		c = &Client{
-			prefix:  s.prefix + newScope,
+			prefix:  joinscopes(s.prefix, newScope),
 			sender:  s.sender,
 			sampler: s.sampler,
 		}
@@ -304,8 +303,12 @@ func NewClient(addr, prefix string) (Statter, error) {
 	return client, nil
 }
 
-// helper method to ensure a dot is added only when necessary
-func dotsuffix(curPrefix, suffix string) string {
+// joinscopes is a helper that ensures we combine scopes with a dot when
+// it's appropriate to do so. Specifically this looks for trailing dots on
+// the existing prefix and leading dots on the new suffix.
+//
+// It returns the new prefix.
+func joinscopes(curPrefix, suffix string) string {
 	var (
 		emptyBase      = curPrefix == ""
 		baseHasDot     = strings.HasSuffix(curPrefix, ".")
@@ -314,10 +317,10 @@ func dotsuffix(curPrefix, suffix string) string {
 	)
 
 	if !emptyBase && !baseHasDot && !suffixLeadsDot && !emptySuffix {
-		return "." + suffix
+		return curPrefix + "." + suffix
 	}
 
-	return suffix
+	return curPrefix + suffix
 }
 
 // Dial is a compatibility alias for NewClient

--- a/statsd/client.go
+++ b/statsd/client.go
@@ -269,13 +269,12 @@ func (s *Client) SetPrefix(prefix string) {
 	s.prefix = prefix
 }
 
-// NewSubStatter returns a SubStatter with an updated prefix that equals the
-// old prefix with 'newScope' appended.
-func (s *Client) NewSubStatter(newScope string) SubStatter {
+// NewSubStatter returns a SubStatter with appended prefix
+func (s *Client) NewSubStatter(prefix string) SubStatter {
 	var c *Client
 	if s != nil {
 		c = &Client{
-			prefix:  joinscopes(s.prefix, newScope),
+			prefix:  joinPathComp(s.prefix, prefix),
 			sender:  s.sender,
 			sampler: s.sampler,
 		}
@@ -303,24 +302,17 @@ func NewClient(addr, prefix string) (Statter, error) {
 	return client, nil
 }
 
-// joinscopes is a helper that ensures we combine scopes with a dot when
-// it's appropriate to do so. Specifically this looks for trailing dots on
-// the existing prefix and leading dots on the new suffix.
+// joinPathComp is a helper that ensures we combine path components with a dot
+// when it's appropriate to do so; prefix is the existing prefix and suffix is
+// the new component being added.
 //
-// It returns the new prefix.
-func joinscopes(curPrefix, suffix string) string {
-	var (
-		emptyBase      = curPrefix == ""
-		baseHasDot     = strings.HasSuffix(curPrefix, ".")
-		emptySuffix    = suffix == ""
-		suffixLeadsDot = strings.HasPrefix(suffix, ".")
-	)
-
-	if !emptyBase && !baseHasDot && !suffixLeadsDot && !emptySuffix {
-		return curPrefix + "." + suffix
+// It returns the joined prefix.
+func joinPathComp(prefix, suffix string) string {
+	suffix = strings.TrimLeft(suffix, ".")
+	if prefix != "" && suffix != "" {
+		return prefix + "." + suffix
 	}
-
-	return curPrefix + suffix
+	return prefix + suffix
 }
 
 // Dial is a compatibility alias for NewClient

--- a/statsd/client_substatter_test.go
+++ b/statsd/client_substatter_test.go
@@ -35,6 +35,8 @@ var statsdSubStatterPacketTests = []struct {
 	{"test", "sub", "GaugeDelta", "gauge", int64(-1), 1.0, "test.sub.gauge:-1|g"},
 	// empty sub prefix -- note: not used in subsub tests
 	{"test", "", "Inc", "count", int64(1), 1.0, "test.count:1|c"},
+	// empty base prefix
+	{"", "sub", "Inc", "count", int64(1), 1.0, "sub.count:1|c"},
 }
 
 func TestSubStatterClient(t *testing.T) {


### PR DESCRIPTION
I was playing around with the client to get a feel for it and noticed that if you didn't specify a base prefix for your `Statter` the stats would arrive with an unexpected format.  Specifically:

```go
  client, err := statsd.NewClient("localhost:8125", "")
  // stuff
  db := client.NewSubStatter("db")
  reads := db.NewSubStatter("reads")
  writes := db.NewSubStatter("writes")

  reads.Inc("cluster."+userid, 1, 1.0)
  writes.Inc("cluster."+userid, 2, 1.0)
```

Produces:

```
.db.reads.cluster.aGVsbG8sIHdvcmxk:1|c
.db.writes.cluster.aGVsbG8sIHdvcmxk:2|c
```

Compared to `statsd.NewClient("localhost:8125", "api")` which yields:

```
api.db.reads.cluster.aGVsbG8sIHdvcmxk:1|c
api.db.writes.cluster.aGVsbG8sIHdvcmxk:2|c
```

I added a test for this case and output before/after my change:
```
$ go test github.com/falun/go-statsd-client/statsd/...
--- FAIL: TestSubStatterClient (0.00s)
	client_substatter_test.go:74: Inc got '.sub.count:1|c' expected 'sub.count:1|c'
--- FAIL: TestMultSubStatterClient (0.00s)
	client_substatter_test.go:125: Inc got '.sub1.count:1|c' expected 'sub.count:1|c'
--- FAIL: TestSubSubStatterClient (0.00s)
	client_substatter_test.go:176: Inc got '.sub.sub2.count:1|c' expected 'sub.count:1|c'
FAIL
FAIL	github.com/falun/go-statsd-client/statsd	0.470s

$ go test github.com/falun/go-statsd-client/statsd/...
ok  	github.com/falun/go-statsd-client/statsd	0.474s
```