### PR TITLE
Reflect configurable Sampler for Statter

### DIFF
--- a/statsd/client.go
+++ b/statsd/client.go
@@ -29,8 +29,7 @@ type StatSender interface {
 
 // The Statter interface defines the behavior of a stat client
 type Statter interface {
-	StatSender
-	NewSubStatter(string) SubStatter
+	SubStatter
 	SetPrefix(string)
 	Close() error
 }


### PR DESCRIPTION
Push `SetSamplerFunc` into `Statter` interface (by embedding `SubStatter`).

Filed [an issue](https://github.com/cactus/go-statsd-client/issues/28) but felt bad about not just pushing since it's trivial.