### PR TITLE
Introduce intermediary constructor for Statter

### DIFF
--- a/statsd/client.go
+++ b/statsd/client.go
@@ -298,7 +298,7 @@ func NewClient(addr, prefix string) (Statter, error) {
 }
 
 func NewClientWithSender(sender Sender, prefix string) Statter {
-	client := &Client{
+	return &Client{
 		prefix: prefix,
 		sender: sender,
 	}

--- a/statsd/client.go
+++ b/statsd/client.go
@@ -5,7 +5,6 @@
 package statsd
 
 import (
-	"errors"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -305,7 +304,7 @@ func NewClient(addr, prefix string) (Statter, error) {
 // prefix is the stastd client prefix. Can be "" if no prefix is desired.
 func NewClientWithSender(sender Sender, prefix string) (Statter, error) {
 	if sender == nil {
-		return nil, errors.New("Client sender may not be nil")
+		return nil, fmt.Errorf("Client sender may not be nil")
 	}
 
 	return &Client{prefix: prefix, sender: sender}, nil

--- a/statsd/client.go
+++ b/statsd/client.go
@@ -5,6 +5,7 @@
 package statsd
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -297,7 +298,16 @@ func NewClient(addr, prefix string) (Statter, error) {
 	return NewClientWithSender(sender, prefix), nil
 }
 
-func NewClientWithSender(sender Sender, prefix string) Statter {
+// NewClientWithSender returns a pointer to a new Client and an error.
+//
+// sender is an instance of a statsd.Sender interface and may not be nil
+//
+// prefix is the stastd client prefix. Can be "" if no prefix is desired.
+func NewClientWithSender(sender Sender, prefix string) (Statter, error) {
+	if sender == nil {
+		return errors.New("Client sender may not be nil")
+	}
+
 	return &Client{
 		prefix: prefix,
 		sender: sender,

--- a/statsd/client.go
+++ b/statsd/client.go
@@ -295,7 +295,7 @@ func NewClient(addr, prefix string) (Statter, error) {
 		return nil, err
 	}
 
-	return NewClientWithSender(sender, prefix), nil
+	return NewClientWithSender(sender, prefix)
 }
 
 // NewClientWithSender returns a pointer to a new Client and an error.
@@ -305,13 +305,10 @@ func NewClient(addr, prefix string) (Statter, error) {
 // prefix is the stastd client prefix. Can be "" if no prefix is desired.
 func NewClientWithSender(sender Sender, prefix string) (Statter, error) {
 	if sender == nil {
-		return errors.New("Client sender may not be nil")
+		return nil, errors.New("Client sender may not be nil")
 	}
 
-	return &Client{
-		prefix: prefix,
-		sender: sender,
-	}
+	return &Client{prefix: prefix, sender: sender}, nil
 }
 
 // joinPathComp is a helper that ensures we combine path components with a dot

--- a/statsd/client.go
+++ b/statsd/client.go
@@ -294,12 +294,14 @@ func NewClient(addr, prefix string) (Statter, error) {
 		return nil, err
 	}
 
+	return NewClientWithSender(sender, prefix), nil
+}
+
+func NewClientWithSender(sender Sender, prefix string) Statter {
 	client := &Client{
 		prefix: prefix,
 		sender: sender,
 	}
-
-	return client, nil
 }
 
 // joinPathComp is a helper that ensures we combine path components with a dot


### PR DESCRIPTION
`statsd.NewClient` produces a `Statter` from a UDP address and the `Statter` doesn't allow any introspection/modifications to how data gets transmitted.  I was going to build a `Statter` for testing but didn't want to spin up a bunch of local UDP listeners and was going to build an in memory collector but ran into a bit of a wall without resorting to casting (which had a bit of a smell to it).

This doesn't change the existing interface and makes it easier to sub in new transport mechanisms if necessary. My immediate use case is for testing (building a sender that puts stats directly into memory for validation) but it could also be used if talking to alternate statsd implementations that support other protocols, authentication, or encryption.