### PR TITLE
Unresolvable destination, connection leak repair

### DIFF
--- a/statsd/sender.go
+++ b/statsd/sender.go
@@ -56,6 +56,7 @@ func NewSimpleSender(addr string) (Sender, error) {
 
 	ra, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {
+		c.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
If the destination address, is non resolvable, the UDP, connection was leaked.

Out of the possible ways to fix it this, seemed like the simplest, 

If this one seems non natural, my alternate suggestion would be to open the UDP listening socket, as the last operation in the method.