### PR TITLE
Add go.mod for Go 1.11 modules support

### DIFF
--- a/statsd/go.mod
+++ b/statsd/go.mod
@@ -1,0 +1,1 @@
+module github.com/cactus/go-statsd-client/statsd


### PR DESCRIPTION
File created via:
```bash
$ go mod init github.com/cactus/go-statsd-client/statsd
$ go mod tidy
```