### PR TITLE
Remove Go Mod version constraint

### DIFF
--- a/statsd/go.mod
+++ b/statsd/go.mod
@@ -1,1 +1,3 @@
 module github.com/cactus/go-statsd-client/statsd
+
+go 1.11

--- a/statsd/go.mod
+++ b/statsd/go.mod
@@ -1,3 +1,1 @@
 module github.com/cactus/go-statsd-client/statsd
-
-go 1.12


### PR DESCRIPTION
Can't import package with go 1.11 modules because of this constraint.