### PR TITLE
Fix tagFormat in SubStatter

### DIFF
--- a/statsd/client.go
+++ b/statsd/client.go
@@ -296,6 +296,7 @@ func (s *Client) NewSubStatter(prefix string) SubStatter {
 			prefix:  joinPathComp(s.prefix, prefix),
 			sender:  s.sender,
 			sampler: s.sampler,
+			tagFormat: s.tagFormat,
 		}
 	}
 	return c


### PR DESCRIPTION
When creating a `NewSubStatter`, the `tagFormat` gets lost. This fixes it by setting it when creating a new `SubStatter`.